### PR TITLE
PEP8 style compliance

### DIFF
--- a/spaceKLIP/contrast.py
+++ b/spaceKLIP/contrast.py
@@ -34,10 +34,10 @@ class Contrast():
     """
     
     def __init__(self,
-                 Database):
+                 database):
         
         # Make an internal alias of the spaceKLIP database class.
-        self.Database = Database
+        self.database = database
         
         pass
     
@@ -45,20 +45,20 @@ class Contrast():
                      subdir='rawcon'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.red.keys()):
+        for i, key in enumerate(self.database.red.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.red[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.red[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.red[key]['FITSFILE'][j]
+                fitsfile = self.database.red[key]['FITSFILE'][j]
                 data, head_pri, head_sci, is2d = ut.read_red(fitsfile)
                 
                 # Compute raw contrast.
@@ -66,18 +66,18 @@ class Contrast():
                 cons = []
                 iwa = 1
                 owa = data.shape[1] // 2
-                pxsc_rad = self.Database.red[key]['PIXSCALE'][j] / 1000. / 3600. / 180. * np.pi
-                resolution = 1e-6 * self.Database.red[key]['CWAVEL'][j] / 6. / pxsc_rad
+                pxsc_rad = self.database.red[key]['PIXSCALE'][j] / 1000. / 3600. / 180. * np.pi
+                resolution = 1e-6 * self.database.red[key]['CWAVEL'][j] / 6. / pxsc_rad
                 center = (head_pri['PSFCENTX'], head_pri['PSFCENTY'])
                 for k in range(data.shape[0]):
                     sep, con = klip.meas_contrast(dat=data[k], iwa=iwa, owa=owa, resolution=resolution, center=center, low_pass_filter=False)
-                    seps += [sep * self.Database.red[key]['PIXSCALE'][j] / 1000.] # arcsec
+                    seps += [sep * self.database.red[key]['PIXSCALE'][j] / 1000.]   # arcsec
                     cons += [con]
                 seps = np.array(seps)
                 cons = np.array(cons)
                 
                 # Plot raw contrast.
-                klmodes = self.Database.red[key]['KLMODES'][j].split(',')
+                klmodes = self.database.red[key]['KLMODES'][j].split(',')
                 fitsfile = os.path.join(output_dir, os.path.split(fitsfile)[1])
                 f = plt.figure(figsize=(6.4, 4.8))
                 ax = plt.gca()

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -195,15 +195,15 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         is_full_frame = 'FULL' in input.meta.subarray.name.upper()
         
         # Get number of custom reference pixel rows & columns.
-        Nlower = self.refpix.nlower
-        Nupper = self.refpix.nupper
-        Nleft = self.refpix.nleft
-        Nright = self.refpix.nright
-        Nall = Nlower + Nupper + Nleft + Nright
+        nlower = self.refpix.nlower
+        nupper = self.refpix.nupper
+        nleft = self.refpix.nleft
+        nright = self.refpix.nright
+        nall = nlower + nupper + nleft + nright
         
         # Run step with default settings if full frame exposure, otherwise run
         # step with custom reference pixel rows & columns.
-        if is_full_frame or Nall == 0:
+        if is_full_frame or nall == 0:
             return self.run_step(self.refpix, input, **kwargs)
         else:
             return self.do_pseudo_refpix(input, **kwargs)
@@ -213,26 +213,26 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
                          **kwargs):
         
         # Get number of custom reference pixel rows & columns.
-        Nlower = self.refpix.nlower
-        Nupper = self.refpix.nupper
-        Nleft = self.refpix.nleft
-        Nright = self.refpix.nright
-        Nrow_off = self.refpix.nrow_off
-        Ncol_off = self.refpix.ncol_off
-        Nupper_off = -Nrow_off if Nrow_off != 0 else None
-        Nright_off = -Ncol_off if Ncol_off != 0 else None
+        nlower = self.refpix.nlower
+        nupper = self.refpix.nupper
+        nleft = self.refpix.nleft
+        nright = self.refpix.nright
+        nrow_off = self.refpix.nrow_off
+        ncol_off = self.refpix.ncol_off
+        nupper_off = -nrow_off if nrow_off != 0 else None
+        nright_off = -ncol_off if ncol_off != 0 else None
         
         # Flag custom reference pixel rows & columns.
-        self.refpix.log.info(f'Flagging [{Nlower}, {Nupper}] references rows at [bottom, top] of array')
-        self.refpix.log.info(f'Flagging [{Nleft}, {Nright}] references columns at [left, right] of array')
-        input.pixeldq[Nrow_off:Nrow_off + Nlower, Ncol_off:Nright_off] = input.pixeldq[Nrow_off:Nrow_off + Nlower, Ncol_off:Nright_off] | dqflags.pixel['REFERENCE_PIXEL']
-        input.pixeldq[-Nrow_off - Nupper:Nupper_off, Ncol_off:Nright_off] = input.pixeldq[-Nrow_off - Nupper:Nupper_off, Ncol_off:Nright_off] | dqflags.pixel['REFERENCE_PIXEL']
-        input.pixeldq[Nrow_off:Nupper_off, Ncol_off:Ncol_off + Nleft]  = input.pixeldq[Nrow_off:Nupper_off, Ncol_off:Ncol_off + Nleft] | dqflags.pixel['REFERENCE_PIXEL']
-        input.pixeldq[Nrow_off:Nupper_off, -Ncol_off - Nright:Nright_off] = input.pixeldq[Nrow_off:Nupper_off, -Ncol_off - Nright:Nright_off] | dqflags.pixel['REFERENCE_PIXEL']
+        self.refpix.log.info(f'Flagging [{nlower}, {nupper}] references rows at [bottom, top] of array')
+        self.refpix.log.info(f'Flagging [{nleft}, {nright}] references columns at [left, right] of array')
+        input.pixeldq[nrow_off:nrow_off + nlower, ncol_off:nright_off] = input.pixeldq[nrow_off:nrow_off + nlower, ncol_off:nright_off] | dqflags.pixel['REFERENCE_PIXEL']
+        input.pixeldq[-nrow_off - nupper:nupper_off, ncol_off:nright_off] = input.pixeldq[-nrow_off - nupper:nupper_off, ncol_off:nright_off] | dqflags.pixel['REFERENCE_PIXEL']
+        input.pixeldq[nrow_off:nupper_off, ncol_off:ncol_off + nleft] = input.pixeldq[nrow_off:nupper_off, ncol_off:ncol_off + nleft] | dqflags.pixel['REFERENCE_PIXEL']
+        input.pixeldq[nrow_off:nupper_off, -ncol_off - nright:nright_off] = input.pixeldq[nrow_off:nupper_off, -ncol_off - nright:nright_off] | dqflags.pixel['REFERENCE_PIXEL']
         
         # Save original step parameter.
         use_side_orig = self.refpix.use_side_ref_pixels
-        if Nleft + Nright == 0:
+        if nleft + nright == 0:
             self.refpix.use_side_ref_pixels = False
         else:
             self.refpix.use_side_ref_pixels = True
@@ -245,33 +245,34 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         
         # Unflag custom reference pixel rows & columns.
         self.refpix.log.info('Removing custom reference pixel flags')
-        res.pixeldq[Nrow_off:Nrow_off + Nlower, Ncol_off:Nright_off] = res.pixeldq[Nrow_off:Nrow_off + Nlower, Ncol_off:Nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
-        res.pixeldq[-Nrow_off - Nupper:Nupper_off, Ncol_off:Nright_off] = res.pixeldq[-Nrow_off - Nupper:Nupper_off, Ncol_off:Nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
-        res.pixeldq[Nrow_off:Nupper_off, Ncol_off:Ncol_off + Nleft] = res.pixeldq[Nrow_off:Nupper_off, Ncol_off:Ncol_off + Nleft] & ~dqflags.pixel['REFERENCE_PIXEL']
-        res.pixeldq[Nrow_off:Nupper_off, -Ncol_off - Nright:Nright_off] = res.pixeldq[Nrow_off:Nupper_off, -Ncol_off - Nright:Nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
+        res.pixeldq[nrow_off:nrow_off + nlower, ncol_off:nright_off] = res.pixeldq[nrow_off:nrow_off + nlower, ncol_off:nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
+        res.pixeldq[-nrow_off - nupper:nupper_off, ncol_off:nright_off] = res.pixeldq[-nrow_off - nupper:nupper_off, ncol_off:nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
+        res.pixeldq[nrow_off:nupper_off, ncol_off:ncol_off + nleft] = res.pixeldq[nrow_off:nupper_off, ncol_off:ncol_off + nleft] & ~dqflags.pixel['REFERENCE_PIXEL']
+        res.pixeldq[nrow_off:nupper_off, -ncol_off - nright:nright_off] = res.pixeldq[nrow_off:nupper_off, -ncol_off - nright:nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
         
         return res
 
-def run_obs(Database,
+
+def run_obs(database,
             steps={},
             subdir='stage1'):
     
     # Set output directory.
-    output_dir = os.path.join(Database.output_dir, subdir)
+    output_dir = os.path.join(database.output_dir, subdir)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     
     # Loop through concatenations.
-    for i, key in enumerate(Database.obs.keys()):
+    for i, key in enumerate(database.obs.keys()):
         log.info('--> Concatenation ' + key)
         
         # Loop through FITS files.
-        Nfitsfiles = len(Database.obs[key])
-        for j in range(Nfitsfiles):
+        nfitsfiles = len(database.obs[key])
+        for j in range(nfitsfiles):
             
             # Skip non-stage 0 files.
-            head, tail = os.path.split(Database.obs[key]['FITSFILE'][j])
-            if Database.obs[key]['DATAMODL'][j] != 'STAGE0':
+            head, tail = os.path.split(database.obs[key]['FITSFILE'][j])
+            if database.obs[key]['DATAMODL'][j] != 'STAGE0':
                 log.info('  --> Coron1Pipeline: skipping non-stage 0 file ' + tail)
                 continue
             log.info('  --> Coron1Pipeline: processing ' + tail)
@@ -286,7 +287,7 @@ def run_obs(Database,
                     setattr(getattr(pipeline, key1), key2, steps[key1][key2])
             
             # Run Coron1Pipeline.
-            fitspath = os.path.abspath(Database.obs[key]['FITSFILE'][j])
+            fitspath = os.path.abspath(database.obs[key]['FITSFILE'][j])
             res = pipeline.run(fitspath)
             if isinstance(res, list):
                 res = res[0]
@@ -296,6 +297,6 @@ def run_obs(Database,
             if fitsfile.endswith('rate.fits'):
                 if os.path.isfile(fitsfile.replace('rate.fits', 'rateints.fits')):
                     fitsfile = fitsfile.replace('rate.fits', 'rateints.fits')
-            Database.update_obs(key, j, fitsfile)
+            database.update_obs(key, j, fitsfile)
     
     pass

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -85,26 +85,27 @@ class Coron2Pipeline_spaceKLIP(Image2Pipeline):
         
         return all_res
 
-def run_obs(Database,
+
+def run_obs(database,
             steps={},
             subdir='stage2'):
     
     # Set output directory.
-    output_dir = os.path.join(Database.output_dir, subdir)
+    output_dir = os.path.join(database.output_dir, subdir)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     
     # Loop through concatenations.
-    for i, key in enumerate(Database.obs.keys()):
+    for i, key in enumerate(database.obs.keys()):
         log.info('--> Concatenation ' + key)
         
         # Loop through FITS files.
-        Nfitsfiles = len(Database.obs[key])
-        for j in range(Nfitsfiles):
+        nfitsfiles = len(database.obs[key])
+        for j in range(nfitsfiles):
             
             # Skip non-stage 1 files.
-            head, tail = os.path.split(Database.obs[key]['FITSFILE'][j])
-            if Database.obs[key]['DATAMODL'][j] != 'STAGE1':
+            head, tail = os.path.split(database.obs[key]['FITSFILE'][j])
+            if database.obs[key]['DATAMODL'][j] != 'STAGE1':
                 log.info('  --> Coron2Pipeline: skipping non-stage 1 file ' + tail)
                 continue
             log.info('  --> Coron2Pipeline: processing ' + tail)
@@ -119,7 +120,7 @@ def run_obs(Database,
                     setattr(getattr(pipeline, key1), key2, steps[key1][key2])
             
             # Run Coron2Pipeline.
-            fitspath = os.path.abspath(Database.obs[key]['FITSFILE'][j])
+            fitspath = os.path.abspath(database.obs[key]['FITSFILE'][j])
             res = pipeline.run(fitspath)
             if isinstance(res, list):
                 res = res[0]
@@ -129,6 +130,6 @@ def run_obs(Database,
             if fitsfile.endswith('cal.fits'):
                 if os.path.isfile(fitsfile.replace('cal.fits', 'calints.fits')):
                     fitsfile = fitsfile.replace('cal.fits', 'calints.fits')
-            Database.update_obs(key, j, fitsfile)
+            database.update_obs(key, j, fitsfile)
     
     pass

--- a/spaceKLIP/coron3pipeline.py
+++ b/spaceKLIP/coron3pipeline.py
@@ -32,23 +32,24 @@ class Coron3Pipeline_spaceKLIP(Coron3Pipeline):
     The spaceKLIP JWST stage 3 pipeline class.
     """
 
-def run_obs(Database,
+
+def run_obs(database,
             steps={},
             subdir='stage3'):
     
     # Set output directory.
-    output_dir = os.path.join(Database.output_dir, subdir)
+    output_dir = os.path.join(database.output_dir, subdir)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     
     # Loop through concatenations.
     datapaths = []
-    for i, key in enumerate(Database.obs.keys()):
+    for i, key in enumerate(database.obs.keys()):
         log.info('--> Concatenation ' + key)
         
         # Make ASN file.
         log.info('  --> Coron3Pipeline: processing ' + key)
-        asnpath = make_asn_file(Database, output_dir, key)
+        asnpath = make_asn_file(database, output_dir, key)
         
         # Initialize Coron1Pipeline.
         pipeline = Coron3Pipeline_spaceKLIP(output_dir=output_dir)
@@ -73,19 +74,20 @@ def run_obs(Database,
         hdul.close()
     
     # Read reductions into database.
-    Database.read_jwst_s3_data(datapaths)
+    database.read_jwst_s3_data(datapaths)
     
     pass
 
-def make_asn_file(Database,
+
+def make_asn_file(database,
                   output_dir,
                   key):
     
     # Find science and reference files.
-    ww_sci = np.where(Database.obs[key]['TYPE'] == 'SCI')[0]
+    ww_sci = np.where(database.obs[key]['TYPE'] == 'SCI')[0]
     if len(ww_sci) == 0:
         raise UserWarning('Concatenation ' + key + ' has no science files')
-    ww_ref = np.where(Database.obs[key]['TYPE'] == 'REF')[0]
+    ww_ref = np.where(database.obs[key]['TYPE'] == 'REF')[0]
     if len(ww_ref) == 0:
         raise UserWarning('Concatenation ' + key + ' has no reference files')
     
@@ -110,12 +112,12 @@ def make_asn_file(Database,
     f.write('            "members": [\n')
     for i in ww_sci:
         f.write('                {\n')
-        f.write('                    "expname": "' + os.path.abspath(Database.obs[key]['FITSFILE'][i]) + '",\n')
+        f.write('                    "expname": "' + os.path.abspath(database.obs[key]['FITSFILE'][i]) + '",\n')
         f.write('                    "exptype": "science"\n')
         f.write('                },\n')
     for i in ww_ref:
         f.write('                {\n')
-        f.write('                    "expname": "' + os.path.abspath(Database.obs[key]['FITSFILE'][i]) + '",\n')
+        f.write('                    "expname": "' + os.path.abspath(database.obs[key]['FITSFILE'][i]) + '",\n')
         f.write('                    "exptype": "psf"\n')
         f.write('                },\n')
     f.write('            ]\n')

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -40,27 +40,28 @@ filter_list = SvoFps.get_filter_list(facility='JWST', instrument='NIRCAM')
 for i in range(len(filter_list)):
     name = filter_list['filterID'][i]
     name = name[name.rfind('.') + 1:]
-    wave_nircam[name] = filter_list['WavelengthMean'][i] / 1e4 # micron
-    weff_nircam[name] = filter_list['WidthEff'][i] / 1e4 # micron
+    wave_nircam[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
+    weff_nircam[name] = filter_list['WidthEff'][i] / 1e4  # micron
 wave_niriss = {}
 weff_niriss = {}
 filter_list = SvoFps.get_filter_list(facility='JWST', instrument='NIRISS')
 for i in range(len(filter_list)):
     name = filter_list['filterID'][i]
     name = name[name.rfind('.') + 1:]
-    wave_niriss[name] = filter_list['WavelengthMean'][i] / 1e4 # micron
-    weff_niriss[name] = filter_list['WidthEff'][i] / 1e4 # micron
+    wave_niriss[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
+    weff_niriss[name] = filter_list['WidthEff'][i] / 1e4  # micron
 wave_miri = {}
 weff_miri = {}
 filter_list = SvoFps.get_filter_list(facility='JWST', instrument='MIRI')
 for i in range(len(filter_list)):
     name = filter_list['filterID'][i]
     name = name[name.rfind('.') + 1:]
-    wave_miri[name] = filter_list['WavelengthMean'][i] / 1e4 # micron
-    weff_miri[name] = filter_list['WidthEff'][i] / 1e4 # micron
-wave_miri['FND'] = 13. # micron
-weff_miri['FND'] = 10. # micron
+    wave_miri[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
+    weff_miri[name] = filter_list['WidthEff'][i] / 1e4  # micron
+wave_miri['FND'] = 13.  # micron
+weff_miri['FND'] = 10.  # micron
 del filter_list
+
 
 class Database():
     """
@@ -113,35 +114,35 @@ class Database():
         DATAMODL = []
         TELESCOP = []
         TARGPROP = []
-        TARG_RA = [] # deg
-        TARG_DEC = [] # deg
+        TARG_RA = []  # deg
+        TARG_DEC = []  # deg
         INSTRUME = []
         DETECTOR = []
         FILTER = []
-        CWAVEL = [] # micron
-        DWAVEL = [] # micron
+        CWAVEL = []  # micron
+        DWAVEL = []  # micron
         PUPIL = []
         CORONMSK = []
         EXP_TYPE = []
-        EXPSTART = [] # MJD
+        EXPSTART = []  # MJD
         NINTS = []
-        EFFINTTM = [] # s
+        EFFINTTM = []  # s
         IS_PSF = []
         SELFREF = []
         SUBARRAY = []
         NUMDTHPT = []
-        XOFFSET = [] # mas
-        YOFFSET = [] # mas
+        XOFFSET = []  # mas
+        YOFFSET = []  # mas
         APERNAME = []
-        PIXSCALE = [] # mas
+        PIXSCALE = []  # mas
         BUNIT = []
-        CRPIX1 = [] # pix
-        CRPIX2 = [] # pix
+        CRPIX1 = []  # pix
+        CRPIX2 = []  # pix
         VPARITY = []
-        V3I_YANG = [] # deg
-        RA_REF = [] # deg
-        DEC_REF = [] # deg
-        ROLL_REF = [] # deg
+        V3I_YANG = []  # deg
+        RA_REF = []  # deg
+        DEC_REF = []  # deg
+        ROLL_REF = []  # deg
         HASH = []
         if psflibpaths is not None:
             allpaths = np.array(datapaths + psflibpaths)
@@ -487,29 +488,29 @@ class Database():
         DATAMODL = []
         TELESCOP = []
         TARGPROP = []
-        TARG_RA = [] # deg
-        TARG_DEC = [] # deg
+        TARG_RA = []  # deg
+        TARG_DEC = []  # deg
         INSTRUME = []
         DETECTOR = []
         FILTER = []
-        CWAVEL = [] # micron
-        DWAVEL = [] # micron
+        CWAVEL = []  # micron
+        DWAVEL = []  # micron
         PUPIL = []
         CORONMSK = []
         EXP_TYPE = []
-        EXPSTART = [] # MJD
+        EXPSTART = []  # MJD
         NINTS = []
-        EFFINTTM = [] # s
+        EFFINTTM = []  # s
         SUBARRAY = []
         APERNAME = []
-        PIXSCALE = [] # mas
+        PIXSCALE = []  # mas
         MODE = []
         ANNULI = []
         SUBSECTS = []
         KLMODES = []
         BUNIT = []
-        CRPIX1 = [] # pix
-        CRPIX2 = [] # pix
+        CRPIX1 = []  # pix
+        CRPIX2 = []  # pix
         HASH = []
         Ndatapaths = len(datapaths)
         for i in range(Ndatapaths):
@@ -574,7 +575,7 @@ class Database():
                 SUBSECTS += [1]
                 try:
                     KLMODES += [str(head['KLMODE0'])]
-                except:
+                except KeyError:
                     log.warning('  --> Could not find KL mode in header, assuming default value of 50')
                     KLMODES += ['50']
             elif TYPE[-1] == 'PYKLIP':
@@ -586,7 +587,7 @@ class Database():
                 while True:
                     try:
                         klmodes += ',' + str(head['KLMODE{0}'.format(j)])
-                    except:
+                    except KeyError:
                         break
                     j += 1
                 KLMODES += [klmodes]

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -40,10 +40,10 @@ class ImageTools():
     """
     
     def __init__(self,
-                 Database):
+                 database):
         
         # Make an internal alias of the spaceKLIP database class.
-        self.Database = Database
+        self.database = database
         
         pass
     
@@ -58,25 +58,25 @@ class ImageTools():
             index = [index]
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
-                nints = self.Database.obs[key]['NINTS'][j]
+                nints = self.database.obs[key]['NINTS'][j]
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Remove frames.
                     try:
@@ -96,7 +96,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile, nints=nints)
+                self.database.update_obs(key, j, fitsfile, nints=nints)
         
         pass
     
@@ -107,31 +107,31 @@ class ImageTools():
         
         # Check input.
         if isinstance(npix, int):
-            npix = [npix, npix, npix, npix] # left, right, bottom, top
+            npix = [npix, npix, npix, npix]  # left, right, bottom, top
         if len(npix) != 4:
             raise UserWarning('Parameter npix must either be an int or a list of four int (left, right, bottom, top)')
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
-                crpix1 = self.Database.obs[key]['CRPIX1'][j]
-                crpix2 = self.Database.obs[key]['CRPIX2'][j]
+                crpix1 = self.database.obs[key]['CRPIX1'][j]
+                crpix2 = self.database.obs[key]['CRPIX2'][j]
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Crop frames.
                     head, tail = os.path.split(fitsfile)
@@ -150,7 +150,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, crpix1=crpix1, crpix2=crpix2)
         
         pass
     
@@ -162,31 +162,31 @@ class ImageTools():
         
         # Check input.
         if isinstance(npix, int):
-            npix = [npix, npix, npix, npix] # left, right, bottom, top
+            npix = [npix, npix, npix, npix]  # left, right, bottom, top
         if len(npix) != 4:
             raise UserWarning('Parameter npix must either be an int or a list of four int (left, right, bottom, top)')
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
-                crpix1 = self.Database.obs[key]['CRPIX1'][j]
-                crpix2 = self.Database.obs[key]['CRPIX2'][j]
+                crpix1 = self.database.obs[key]['CRPIX1'][j]
+                crpix2 = self.database.obs[key]['CRPIX2'][j]
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Crop frames.
                     head, tail = os.path.split(fitsfile)
@@ -205,7 +205,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, crpix1=crpix1, crpix2=crpix2)
         
         pass
     
@@ -215,40 +215,40 @@ class ImageTools():
                      subdir='coadded'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
-                nints = self.Database.obs[key]['NINTS'][j]
-                effinttm = self.Database.obs[key]['EFFINTTM'][j]
+                nints = self.database.obs[key]['NINTS'][j]
+                effinttm = self.database.obs[key]['EFFINTTM'][j]
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Coadd frames.
                     head, tail = os.path.split(fitsfile)
                     log.info('  --> Frame coadding: ' + tail)
-                    Ncoadds = data.shape[0] // nframes
-                    data = np.nanmedian(data[:nframes * Ncoadds].reshape((nframes, Ncoadds, data.shape[-2], data.shape[-1])), axis=0)
-                    erro = np.nanmedian(erro[:nframes * Ncoadds].reshape((nframes, Ncoadds, erro.shape[-2], erro.shape[-1])), axis=0)
-                    pxdq_temp = pxdq[:nframes * Ncoadds].reshape((nframes, Ncoadds, pxdq.shape[-2], pxdq.shape[-1]))
+                    ncoadds = data.shape[0] // nframes
+                    data = np.nanmedian(data[:nframes * ncoadds].reshape((nframes, ncoadds, data.shape[-2], data.shape[-1])), axis=0)
+                    erro = np.nanmedian(erro[:nframes * ncoadds].reshape((nframes, ncoadds, erro.shape[-2], erro.shape[-1])), axis=0)
+                    pxdq_temp = pxdq[:nframes * ncoadds].reshape((nframes, ncoadds, pxdq.shape[-2], pxdq.shape[-1]))
                     pxdq = pxdq_temp[0]
                     for k in range(1, nframes):
                         pxdq = np.bitwise_or(pxdq, pxdq_temp[k])
                     nints = data.shape[0]
                     effinttm *= nframes
-                    log.info('  --> Frame coadding: %.0f coadd(s) of %.0f frame(s)' % (Ncoadds, nframes))
+                    log.info('  --> Frame coadding: %.0f coadd(s) of %.0f frame(s)' % (ncoadds, nframes))
                 
                 # Write FITS file.
                 head_pri['NINTS'] = nints
@@ -256,7 +256,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile, nints=nints, effinttm=effinttm)
+                self.database.update_obs(key, j, fitsfile, nints=nints, effinttm=effinttm)
         
         pass
     
@@ -265,30 +265,30 @@ class ImageTools():
                         subdir='medsub'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Subtract median.
                     head, tail = os.path.split(fitsfile)
                     log.info('  --> Median subtraction: ' + tail)
                     data_temp = data.copy()
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     data_temp[pxdq != 0] = np.nan
                     # else:
                     #     data_temp[pxdq & 1 == 1] = np.nan
@@ -300,25 +300,25 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile)
+                self.database.update_obs(key, j, fitsfile)
     
     def subtract_background(self,
                             subdir='bgsub'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Find science and reference files.
-            ww_sci = np.where(self.Database.obs[key]['TYPE'] == 'SCI')[0]
-            ww_sci_bg = np.where(self.Database.obs[key]['TYPE'] == 'SCI_BG')[0]
-            ww_ref = np.where(self.Database.obs[key]['TYPE'] == 'REF')[0]
-            ww_ref_bg = np.where(self.Database.obs[key]['TYPE'] == 'REF_BG')[0]
+            ww_sci = np.where(self.database.obs[key]['TYPE'] == 'SCI')[0]
+            ww_sci_bg = np.where(self.database.obs[key]['TYPE'] == 'SCI_BG')[0]
+            ww_ref = np.where(self.database.obs[key]['TYPE'] == 'REF')[0]
+            ww_ref_bg = np.where(self.database.obs[key]['TYPE'] == 'REF_BG')[0]
             
             # Loop through science background files.
             if len(ww_sci_bg) != 0:
@@ -328,7 +328,7 @@ class ImageTools():
                 for j in ww_sci_bg:
                     
                     # Read science background file.
-                    fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                    fitsfile = self.database.obs[key]['FITSFILE'][j]
                     data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                     
                     # Compute median science background.
@@ -339,9 +339,9 @@ class ImageTools():
                 sci_bg_erro = np.concatenate(sci_bg_erro)
                 sci_bg_pxdq = np.concatenate(sci_bg_pxdq)
                 sci_bg_data = np.nanmedian(sci_bg_data, axis=0)
-                Nsample = np.sum(np.logical_not(np.isnan(sci_bg_erro)), axis=0)
-                sci_bg_erro = np.true_divide(np.sqrt(np.nansum(sci_bg_erro**2, axis=0)), Nsample)
-                # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                nsample = np.sum(np.logical_not(np.isnan(sci_bg_erro)), axis=0)
+                sci_bg_erro = np.true_divide(np.sqrt(np.nansum(sci_bg_erro**2, axis=0)), nsample)
+                # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                 #     sci_bg_pxdq = np.sum(sci_bg_pxdq != 0, axis=0) != 0
                 # else:
                 sci_bg_pxdq = np.sum(sci_bg_pxdq & 1 == 1, axis=0) != 0
@@ -356,7 +356,7 @@ class ImageTools():
                 for j in ww_ref_bg:
                     
                     # Read reference background file.
-                    fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                    fitsfile = self.database.obs[key]['FITSFILE'][j]
                     data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                     
                     # Compute median reference background.
@@ -367,9 +367,9 @@ class ImageTools():
                 ref_bg_erro = np.concatenate(ref_bg_erro)
                 ref_bg_pxdq = np.concatenate(ref_bg_pxdq)
                 ref_bg_data = np.nanmedian(ref_bg_data, axis=0)
-                Nsample = np.sum(np.logical_not(np.isnan(ref_bg_erro)), axis=0)
-                ref_bg_erro = np.true_divide(np.sqrt(np.nansum(ref_bg_erro**2, axis=0)), Nsample)
-                # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                nsample = np.sum(np.logical_not(np.isnan(ref_bg_erro)), axis=0)
+                ref_bg_erro = np.true_divide(np.sqrt(np.nansum(ref_bg_erro**2, axis=0)), nsample)
+                # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                 #     ref_bg_pxdq = np.sum(ref_bg_pxdq != 0, axis=0) != 0
                 # else:
                 ref_bg_pxdq = np.sum(ref_bg_pxdq & 1 == 1, axis=0) != 0
@@ -388,7 +388,7 @@ class ImageTools():
                     sci = False
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                 
                 # Subtract background.
@@ -408,7 +408,7 @@ class ImageTools():
                     
                     data = data - sci_bg_data
                     erro = np.sqrt(erro**2 + sci_bg_erro**2)
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq[(pxdq == 0) & (sci_bg_pxdq != 0)] += 1
                     # else:
                     pxdq[np.logical_not(pxdq & 1 == 1) & (sci_bg_pxdq != 0)] += 1
@@ -416,14 +416,14 @@ class ImageTools():
                     log.warning('  --> Could not find science background, attempting to use reference background')
                     data = data - ref_bg_data
                     erro = np.sqrt(erro**2 + ref_bg_erro**2)
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq[(pxdq == 0) & (ref_bg_pxdq != 0)] += 1
                     # else:
                     pxdq[np.logical_not(pxdq & 1 == 1) & (ref_bg_pxdq != 0)] += 1
                 elif not sci and ref_bg_data is not None:
                     data = data - ref_bg_data
                     erro = np.sqrt(erro**2 + ref_bg_erro**2)
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq[(pxdq == 0) & (ref_bg_pxdq != 0)] += 1
                     # else:
                     pxdq[np.logical_not(pxdq & 1 == 1) & (ref_bg_pxdq != 0)] += 1
@@ -431,7 +431,7 @@ class ImageTools():
                     log.warning('  --> Could not find reference background, attempting to use science background')
                     data = data - sci_bg_data
                     erro = np.sqrt(erro**2 + sci_bg_erro**2)
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq[(pxdq == 0) & (sci_bg_pxdq != 0)] += 1
                     # else:
                     pxdq[np.logical_not(pxdq & 1 == 1) & (sci_bg_pxdq != 0)] += 1
@@ -440,7 +440,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile)
+                self.database.update_obs(key, j, fitsfile)
         
         pass
     
@@ -455,28 +455,28 @@ class ImageTools():
                        subdir='bpcleaned'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Call bad pixel cleaning routines.
                     pxdq_temp = pxdq.copy()
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq_temp = (pxdq_temp != 0) & np.logical_not(pxdq_temp & 512 == 512)
                     # else:
                     pxdq_temp = (np.isnan(data) | (pxdq_temp & 1 == 1)) & np.logical_not(pxdq_temp & 512 == 512)
@@ -500,7 +500,7 @@ class ImageTools():
                             self.fix_bad_pixels_medfilt(data, erro, pxdq_temp, medfilt_kwargs)
                         else:
                             log.info('  --> Unknown method ' + method_split[k] + ': skipped')
-                    # if self.Database.obs[key]['TELESCOP'][j] == 'JWST' and self.Database.obs[key]['INSTRUME'][j] == 'NIRCAM':
+                    # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq[(pxdq != 0) & np.logical_not(pxdq & 512 == 512) & (pxdq_temp == 0)] = 0
                     # else:
                     # pxdq[(pxdq & 1 == 1) & np.logical_not(pxdq & 512 == 512) & (pxdq_temp == 0)] = 0
@@ -509,7 +509,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile)
+                self.database.update_obs(key, j, fitsfile)
         
         pass
     
@@ -559,7 +559,7 @@ class ImageTools():
             # Get median background and standard deviation.
             bg_med = np.nanmedian(data_temp[i])
             bg_std = robust.medabsdev(data_temp[i])
-            bg_ind = data[i] < (bg_med + 10. * bg_std) # clip bright PSFs for final calculation
+            bg_ind = data[i] < (bg_med + 10. * bg_std)  # clip bright PSFs for final calculation
             bg_med = np.nanmedian(data_temp[i][bg_ind])
             bg_std = robust.medabsdev(data_temp[i][bg_ind])
             
@@ -588,11 +588,11 @@ class ImageTools():
                 data_std = np.nanstd(data_arr, axis=0)
                 # data_std = robust.medabsdev(data_arr, axis=0)
                 mask_new = diff > bpclean_kwargs['sigclip'] * data_std
-                Nmask_new = np.sum(mask_new & np.logical_not(ww[i]))
-                # print('Iteration %.0f: %.0f bad pixels identified, %.0f are new' % (it + 1, np.sum(mask_new), Nmask_new))
+                nmask_new = np.sum(mask_new & np.logical_not(ww[i]))
+                # print('Iteration %.0f: %.0f bad pixels identified, %.0f are new' % (it + 1, np.sum(mask_new), nmask_new))
                 sys.stdout.write('\rFrame %.0f/%.0f, iteration %.0f' % (i + 1, ww.shape[0], it + 1))
                 sys.stdout.flush()
-                if it > 0 and Nmask_new == 0:
+                if it > 0 and nmask_new == 0:
                     break
                 ww[i] = ww[i] | mask_new
             ww[i][NON_SCIENCE[i]] = 0
@@ -728,24 +728,24 @@ class ImageTools():
                      subdir='nanreplaced'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Loop through FITS files.
-            Nfitsfiles = len(self.Database.obs[key])
-            for j in range(Nfitsfiles):
+            nfitsfiles = len(self.database.obs[key])
+            for j in range(nfitsfiles):
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                 
                 # Skip file types that are not in the list of types.
-                if self.Database.obs[key]['TYPE'][j] in types:
+                if self.database.obs[key]['TYPE'][j] in types:
                     
                     # Replace nans.
                     head, tail = os.path.split(fitsfile)
@@ -758,7 +758,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile)
+                self.database.update_obs(key, j, fitsfile)
         
         pass
     
@@ -768,20 +768,20 @@ class ImageTools():
                      subdir='aligned'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        Database_temp = deepcopy(self.Database.obs)
-        for i, key in enumerate(self.Database.obs.keys()):
+        database_temp = deepcopy(self.database.obs)
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Find science and reference files.
-            ww_sci = np.where(self.Database.obs[key]['TYPE'] == 'SCI')[0]
+            ww_sci = np.where(self.database.obs[key]['TYPE'] == 'SCI')[0]
             if len(ww_sci) == 0:
                 raise UserWarning('Could not find any science files')
-            ww_ref = np.where(self.Database.obs[key]['TYPE'] == 'REF')[0]
+            ww_ref = np.where(self.database.obs[key]['TYPE'] == 'REF')[0]
             ww_all = np.append(ww_sci, ww_ref)
             
             # Loop through FITS files.
@@ -789,7 +789,7 @@ class ImageTools():
             for j in ww_all:
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                 
                 # Align frames.
@@ -803,12 +803,12 @@ class ImageTools():
                     if j == ww_sci[0] and k == 0:
                         ref_image = data[k].copy()
                         pp = np.array([0., 0., 1.])
-                        xoffset = self.Database.obs[key]['XOFFSET'][j]
-                        yoffset = self.Database.obs[key]['YOFFSET'][j]
-                        crpix1 = self.Database.obs[key]['CRPIX1'][j]
-                        crpix2 = self.Database.obs[key]['CRPIX2'][j]
+                        xoffset = self.database.obs[key]['XOFFSET'][j]
+                        yoffset = self.database.obs[key]['YOFFSET'][j]
+                        crpix1 = self.database.obs[key]['CRPIX1'][j]
+                        crpix2 = self.database.obs[key]['CRPIX2'][j]
                     else:
-                        p0 = np.array([((crpix1 + xoffset) - (self.Database.obs[key]['CRPIX1'][j] + self.Database.obs[key]['XOFFSET'][j])) / self.Database.obs[key]['PIXSCALE'][j], ((crpix2 + yoffset) - (self.Database.obs[key]['CRPIX2'][j] + self.Database.obs[key]['YOFFSET'][j])) / self.Database.obs[key]['PIXSCALE'][j], 1.])
+                        p0 = np.array([((crpix1 + xoffset) - (self.database.obs[key]['CRPIX1'][j] + self.database.obs[key]['XOFFSET'][j])) / self.database.obs[key]['PIXSCALE'][j], ((crpix2 + yoffset) - (self.database.obs[key]['CRPIX2'][j] + self.database.obs[key]['YOFFSET'][j])) / self.database.obs[key]['PIXSCALE'][j], 1.])
                         pp = leastsq(self.alignlsq,
                                      p0,
                                      args=(data[k], ref_image, mask, method, kwargs))[0]
@@ -820,12 +820,12 @@ class ImageTools():
                 shifts_all += [shifts]
                 
                 # Compute shift distances.
-                dist = np.sqrt(np.sum(shifts[:, :2]**2, axis=1)) # pix
-                dist *= self.Database.obs[key]['PIXSCALE'][j] # mas
+                dist = np.sqrt(np.sum(shifts[:, :2]**2, axis=1))  # pix
+                dist *= self.database.obs[key]['PIXSCALE'][j]  # mas
                 if j == ww_sci[0]:
                     dist = dist[1:]
                 log.info('  --> Align frames: median required shift = %.2f mas' % np.median(dist))
-                if self.Database.obs[key]['TELESCOP'][j] == 'JWST':
+                if self.database.obs[key]['TELESCOP'][j] == 'JWST':
                     ww = (dist < 1e-5) | (dist > 100.)
                 else:
                     ww = (dist < 1e-5)
@@ -843,14 +843,14 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile, xoffset=xoffset, yoffset=yoffset, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, xoffset=xoffset, yoffset=yoffset, crpix1=crpix1, crpix2=crpix2)
             
             # Plot science frame alignment.
             colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
             f = plt.figure(figsize=(6.4, 4.8))
             ax = plt.gca()
             for index, j in enumerate(ww_sci):
-                ax.scatter(shifts_all[index][:, 0] * self.Database.obs[key]['PIXSCALE'][j], shifts_all[index][:, 1] * self.Database.obs[key]['PIXSCALE'][j], s=5, color=colors[index], marker='o', label='PA = %.0f deg' % self.Database.obs[key]['ROLL_REF'][j])
+                ax.scatter(shifts_all[index][:, 0] * self.database.obs[key]['PIXSCALE'][j], shifts_all[index][:, 1] * self.database.obs[key]['PIXSCALE'][j], s=5, color=colors[index], marker='o', label='PA = %.0f deg' % self.database.obs[key]['ROLL_REF'][j])
             ax.axhline(0., color='gray', lw=1)
             ax.axvline(0., color='gray', lw=1)
             ax.set_aspect('equal')
@@ -881,16 +881,16 @@ class ImageTools():
             syms = ['o', 'v', '^', '<', '>']
             add = len(ww_sci)
             for index, j in enumerate(ww_ref):
-                this = '%.0f_%.0f' % (Database_temp[key]['XOFFSET'][j], Database_temp[key]['YOFFSET'][j])
+                this = '%.0f_%.0f' % (database_temp[key]['XOFFSET'][j], database_temp[key]['YOFFSET'][j])
                 if this not in seen:
-                    ax.scatter(shifts_all[index + add][:, 0] * self.Database.obs[key]['PIXSCALE'][j], shifts_all[index + add][:, 1] * self.Database.obs[key]['PIXSCALE'][j], s=5, color=colors[len(seen)], marker=syms[0], label='dpos %.0f' % (len(seen) + 1))
-                    ax.hlines(-Database_temp[key]['YOFFSET'][j] + yoffset, -Database_temp[key]['XOFFSET'][j] + xoffset - 4., -Database_temp[key]['XOFFSET'][j] + xoffset + 4., color=colors[len(seen)], lw=1)
-                    ax.vlines(-Database_temp[key]['XOFFSET'][j] + xoffset, -Database_temp[key]['YOFFSET'][j] + yoffset - 4., -Database_temp[key]['YOFFSET'][j] + yoffset + 4., color=colors[len(seen)], lw=1)
+                    ax.scatter(shifts_all[index + add][:, 0] * self.database.obs[key]['PIXSCALE'][j], shifts_all[index + add][:, 1] * self.database.obs[key]['PIXSCALE'][j], s=5, color=colors[len(seen)], marker=syms[0], label='dpos %.0f' % (len(seen) + 1))
+                    ax.hlines(-database_temp[key]['YOFFSET'][j] + yoffset, -database_temp[key]['XOFFSET'][j] + xoffset - 4., -database_temp[key]['XOFFSET'][j] + xoffset + 4., color=colors[len(seen)], lw=1)
+                    ax.vlines(-database_temp[key]['XOFFSET'][j] + xoffset, -database_temp[key]['YOFFSET'][j] + yoffset - 4., -database_temp[key]['YOFFSET'][j] + yoffset + 4., color=colors[len(seen)], lw=1)
                     seen += [this]
                     reps += [1]
                 else:
                     ww = np.where(np.array(seen) == this)[0][0]
-                    ax.scatter(shifts_all[index + add][:, 0] * self.Database.obs[key]['PIXSCALE'][j], shifts_all[index + add][:, 1] * self.Database.obs[key]['PIXSCALE'][j], s=5, color=colors[ww], marker=syms[reps[ww]])
+                    ax.scatter(shifts_all[index + add][:, 0] * self.database.obs[key]['PIXSCALE'][j], shifts_all[index + add][:, 1] * self.database.obs[key]['PIXSCALE'][j], s=5, color=colors[ww], marker=syms[reps[ww]])
                     reps[ww] += 1
             ax.set_aspect('equal')
             xlim = ax.get_xlim()
@@ -919,23 +919,23 @@ class ImageTools():
                         subdir='recentered'):
         
         # Set output directory.
-        output_dir = os.path.join(self.Database.output_dir, subdir)
+        output_dir = os.path.join(self.database.output_dir, subdir)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         
         # Loop through concatenations.
-        for i, key in enumerate(self.Database.obs.keys()):
+        for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
             
             # Find TA files.
-            ww_ta = np.append(np.where(self.Database.obs[key]['TYPE'] == 'SCI_TA')[0], np.where(self.Database.obs[key]['TYPE'] == 'REF_TA')[0])
+            ww_ta = np.append(np.where(self.database.obs[key]['TYPE'] == 'SCI_TA')[0], np.where(self.database.obs[key]['TYPE'] == 'REF_TA')[0])
             
             # Loop through FITS files.
             shifts_all = []
             for j in ww_ta:
                 
                 # Read FITS file.
-                fitsfile = self.Database.obs[key]['FITSFILE'][j]
+                fitsfile = self.database.obs[key]['FITSFILE'][j]
                 data, erro, pxdq, head_pri, head_sci, is2d = ut.read_obs(fitsfile)
                 
                 # Recenter frames.
@@ -944,10 +944,10 @@ class ImageTools():
                 if np.sum(np.isnan(data)) != 0:
                     raise UserWarning('Please replace nan pixels before attempting to recenter frames')
                 shifts = []
-                xoffset = 0. # mas
-                yoffset = 0. # mas
-                crpix1 = data.shape[-1]//2 + 1 # 1-indexed
-                crpix2 = data.shape[-2]//2 + 1 # 1-indexed
+                xoffset = 0.  # mas
+                yoffset = 0.  # mas
+                crpix1 = data.shape[-1]//2 + 1  # 1-indexed
+                crpix2 = data.shape[-2]//2 + 1  # 1-indexed
                 for k in range(data.shape[0]):
                     p0 = np.array([0., 0.])
                     pp = minimize(self.recenterlsq,
@@ -967,9 +967,9 @@ class ImageTools():
                 shifts_all += [shifts]
                 
                 # Compute shift distances.
-                dist = np.sqrt(np.sum(shifts[:, :2]**2, axis=1)) # pix
-                dist *= self.Database.obs[key]['PIXSCALE'][j] # mas
-                head, tail = os.path.split(self.Database.obs[key]['FITSFILE'][j])
+                dist = np.sqrt(np.sum(shifts[:, :2]**2, axis=1))  # pix
+                dist *= self.database.obs[key]['PIXSCALE'][j]  # mas
+                head, tail = os.path.split(self.database.obs[key]['FITSFILE'][j])
                 log.info('  --> Align frames: ' + tail)
                 log.info('  --> Align frames: median required shift = %.2f mas' % np.median(dist))
                 ww = dist > 300.
@@ -985,7 +985,7 @@ class ImageTools():
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d)
                 
                 # Update spaceKLIP database.
-                self.Database.update_obs(key, j, fitsfile, xoffset=xoffset, yoffset=yoffset, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, xoffset=xoffset, yoffset=yoffset, crpix1=crpix1, crpix2=crpix2)
         
         pass
     

--- a/spaceKLIP/mast.py
+++ b/spaceKLIP/mast.py
@@ -16,7 +16,8 @@ import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
 
-import astropy, astroquery
+import astropy
+import astroquery
 from astroquery.mast import Mast
 
 import logging
@@ -31,7 +32,8 @@ log.setLevel(logging.INFO)
 def set_params(parameters):
     """Utility function for making dicts used in MAST queries"""
     
-    return [{'paramName':p, 'values':v} for p, v in parameters.items()]
+    return [{'paramName': p, 'values': v} for p, v in parameters.items()]
+
 
 def query_coron_datasets(inst,
                          filt,
@@ -67,7 +69,7 @@ def query_coron_datasets(inst,
     # filter/occulter.
     if inst.upper() == 'MIRI':
         service = 'Mast.Jwst.Filtered.Miri'
-        template ='MIRI Coronagraphic Imaging'
+        template = 'MIRI Coronagraphic Imaging'
     else:
         service = 'Mast.Jwst.Filtered.NIRCam'
         template = 'NIRCam Coronagraphic Imaging'
@@ -81,7 +83,7 @@ def query_coron_datasets(inst,
     if mask is not None:
         keywords['coronmsk'] = [mask]
     if ignore_cal:
-        keywords['category'] = ['COM','ERS', 'GTO', 'GO'] # but not CAL
+        keywords['category'] = ['COM', 'ERS', 'GTO', 'GO']  # but not CAL
     
     # Optional, restrict to one kind of coronagraphic data
     if kind == 'SCI':
@@ -94,20 +96,20 @@ def query_coron_datasets(inst,
         keywords['is_psf'] = ['f']
         keywords['bkgdtarg'] = ['t']
     
-	# Method note: we query MAST for much more than we actually need/want, and
+    # Method note: we query MAST for much more than we actually need/want, and
     # then filter down afterwards. This is not entirely necessary, but leaves
     # room for future expansion to add options for more verbose output, etc.
     # Currently this works by retrieving all level2b (i.e., cal/calints)
     # files, including all dithers etc., and then trimming to one unique row
     # per observation.
     collist = 'filename, productLevel, bkgdtarg, bstrtime, duration, effexptm, effinttm, exp_type, filter, coronmsk, is_psf, nexposur, nframes, nints, numdthpt, obs_id, obslabel, pi_name, program, subarray, targname, template, title, visit_id, visitsta, vststart_mjd, isRestricted'
-    all_columns=False
+    all_columns = False
     
     parameters = {'columns': '*' if all_columns else collist,
                   'filters': set_params(keywords)}
     
     response = Mast.service_request(service, parameters)
-    response.sort(keys = 'bstrtime')
+    response.sort(keys='bstrtime')
     
     # Summarize the distinct observations conveniently.
     cols_to_keep = ['visit_id', 'filter', 'coronmsk', 'targname', 'obslabel',
@@ -124,7 +126,7 @@ def query_coron_datasets(inst,
     
     # Add a summary for which kind of observation each is.
     kind = np.zeros(len(response), dtype='a3')
-    kind[:] = 'SCI' # by default assume SCI, then check for REF and BKG
+    kind[:] = 'SCI'  # by default assume SCI, then check for REF and BKG
     kind[response.columns['is_psf'] == 't'] = 'REF'
     kind[response.columns['bkgdtarg'] == 't'] = 'BKG'
     kind[kind == ''] = 'SCI'

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -148,12 +148,12 @@ class SpaceTelescope(Data):
         
         # Loop through science files.
         input_all = []
-        centers_all = [] # pix
+        centers_all = []  # pix
         filenames_all = []
-        PAs_all = [] # deg
-        wvs_all = [] # m
+        PAs_all = []  # deg
+        wvs_all = []  # m
         wcs_all = []
-        PIXSCALE = [] # mas
+        PIXSCALE = []  # mas
         for i, filepath in enumerate(filepaths):
             
             # Read science file.
@@ -199,9 +199,9 @@ class SpaceTelescope(Data):
         if len(PIXSCALE) != 1:
             raise UserWarning('Some science files do not have matching pixel scales')
         if TELESCOP == 'JWST' and obs['EXP_TYPE'][ww] in ['NRC_CORON', 'MIR_4QPM', 'MIR_LYOT']:
-            iwa_all = np.min(wvs_all) / 6.5 * 180. / np.pi * 3600. * 1000. / PIXSCALE[0] # pix
+            iwa_all = np.min(wvs_all) / 6.5 * 180. / np.pi * 3600. * 1000. / PIXSCALE[0]  # pix
         else:
-            iwa_all = 1. # pix
+            iwa_all = 1.  # pix
         
         # Recenter science images.
         new_center = np.array(data.shape[1:]) / 2.
@@ -235,7 +235,7 @@ class SpaceTelescope(Data):
         
         # Loop through reference files.
         psflib_data_all = []
-        psflib_centers_all = [] # pix
+        psflib_centers_all = []  # pix
         psflib_filenames_all = []
         for i, filepath in enumerate(psflib_filepaths):
             
@@ -366,7 +366,8 @@ class SpaceTelescope(Data):
         
         pass
 
-def run_obs(Database,
+
+def run_obs(database,
             kwargs={},
             subdir='klipsub'):
     
@@ -392,17 +393,17 @@ def run_obs(Database,
         kwargs_temp['movement'] = 1.
     kwargs_temp['calibrate_flux'] = False
     if 'verbose' not in kwargs_temp.keys():
-        kwargs_temp['verbose'] = Database.verbose
+        kwargs_temp['verbose'] = database.verbose
     
     # Set output directory.
-    output_dir = os.path.join(Database.output_dir, subdir)
+    output_dir = os.path.join(database.output_dir, subdir)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     kwargs_temp['outputdir'] = output_dir
     
     # Loop through concatenations.
     datapaths = []
-    for i, key in enumerate(Database.obs.keys()):
+    for i, key in enumerate(database.obs.keys()):
         log.info('--> Concatenation ' + key)
         
         # Find science and reference files.
@@ -410,17 +411,17 @@ def run_obs(Database,
         psflib_filepaths = []
         first_sci = True
         nints = []
-        Nfitsfiles = len(Database.obs[key])
+        Nfitsfiles = len(database.obs[key])
         for j in range(Nfitsfiles):
-            if Database.obs[key]['TYPE'][j] == 'SCI':
-                filepaths += [Database.obs[key]['FITSFILE'][j]]
+            if database.obs[key]['TYPE'][j] == 'SCI':
+                filepaths += [database.obs[key]['FITSFILE'][j]]
                 if first_sci:
                     first_sci = False
                 else:
-                    nints += [Database.obs[key]['NINTS'][j]]
-            elif Database.obs[key]['TYPE'][j] == 'REF':
-                psflib_filepaths += [Database.obs[key]['FITSFILE'][j]]
-                nints += [Database.obs[key]['NINTS'][j]]
+                    nints += [database.obs[key]['NINTS'][j]]
+            elif database.obs[key]['TYPE'][j] == 'REF':
+                psflib_filepaths += [database.obs[key]['FITSFILE'][j]]
+                nints += [database.obs[key]['NINTS'][j]]
         filepaths = np.array(filepaths)
         psflib_filepaths = np.array(psflib_filepaths)
         nints = np.array(nints)
@@ -429,7 +430,7 @@ def run_obs(Database,
             kwargs_temp['maxnumbasis'] = maxnumbasis
         
         # Initialize pyKLIP dataset.
-        dataset = SpaceTelescope(Database.obs[key], filepaths, psflib_filepaths)
+        dataset = SpaceTelescope(database.obs[key], filepaths, psflib_filepaths)
         kwargs_temp['dataset'] = dataset
         kwargs_temp['aligned_center'] = dataset._centers[0]
         kwargs_temp['psf_library'] = dataset.psflib
@@ -451,34 +452,34 @@ def run_obs(Database,
                     datapaths += [datapath]
                     
                     # Update reduction header.
-                    ww_sci = np.where(Database.obs[key]['TYPE'] == 'SCI')[0]
+                    ww_sci = np.where(database.obs[key]['TYPE'] == 'SCI')[0]
                     hdul = pyfits.open(datapath)
-                    hdul[0].header['TELESCOP'] = Database.obs[key]['TELESCOP'][ww_sci[0]]
-                    hdul[0].header['TARGPROP'] = Database.obs[key]['TARGPROP'][ww_sci[0]]
-                    hdul[0].header['TARG_RA'] = Database.obs[key]['TARG_RA'][ww_sci[0]]
-                    hdul[0].header['TARG_DEC'] = Database.obs[key]['TARG_DEC'][ww_sci[0]]
-                    hdul[0].header['INSTRUME'] = Database.obs[key]['INSTRUME'][ww_sci[0]]
-                    hdul[0].header['DETECTOR'] = Database.obs[key]['DETECTOR'][ww_sci[0]]
-                    hdul[0].header['FILTER'] = Database.obs[key]['FILTER'][ww_sci[0]]
-                    hdul[0].header['CWAVEL'] = Database.obs[key]['CWAVEL'][ww_sci[0]]
-                    hdul[0].header['DWAVEL'] = Database.obs[key]['DWAVEL'][ww_sci[0]]
-                    hdul[0].header['PUPIL'] = Database.obs[key]['PUPIL'][ww_sci[0]]
-                    hdul[0].header['CORONMSK'] = Database.obs[key]['CORONMSK'][ww_sci[0]]
-                    hdul[0].header['EXP_TYPE'] = Database.obs[key]['EXP_TYPE'][ww_sci[0]]
-                    hdul[0].header['EXPSTART'] = np.min(Database.obs[key]['EXPSTART'][ww_sci])
-                    hdul[0].header['NINTS'] = np.sum(Database.obs[key]['NINTS'][ww_sci])
-                    hdul[0].header['EFFINTTM'] = Database.obs[key]['EFFINTTM'][ww_sci[0]]
-                    hdul[0].header['SUBARRAY'] = Database.obs[key]['SUBARRAY'][ww_sci[0]]
-                    hdul[0].header['APERNAME'] = Database.obs[key]['APERNAME'][ww_sci[0]]
-                    hdul[0].header['PIXSCALE'] = Database.obs[key]['PIXSCALE'][ww_sci[0]]
+                    hdul[0].header['TELESCOP'] = database.obs[key]['TELESCOP'][ww_sci[0]]
+                    hdul[0].header['TARGPROP'] = database.obs[key]['TARGPROP'][ww_sci[0]]
+                    hdul[0].header['TARG_RA'] = database.obs[key]['TARG_RA'][ww_sci[0]]
+                    hdul[0].header['TARG_DEC'] = database.obs[key]['TARG_DEC'][ww_sci[0]]
+                    hdul[0].header['INSTRUME'] = database.obs[key]['INSTRUME'][ww_sci[0]]
+                    hdul[0].header['DETECTOR'] = database.obs[key]['DETECTOR'][ww_sci[0]]
+                    hdul[0].header['FILTER'] = database.obs[key]['FILTER'][ww_sci[0]]
+                    hdul[0].header['CWAVEL'] = database.obs[key]['CWAVEL'][ww_sci[0]]
+                    hdul[0].header['DWAVEL'] = database.obs[key]['DWAVEL'][ww_sci[0]]
+                    hdul[0].header['PUPIL'] = database.obs[key]['PUPIL'][ww_sci[0]]
+                    hdul[0].header['CORONMSK'] = database.obs[key]['CORONMSK'][ww_sci[0]]
+                    hdul[0].header['EXP_TYPE'] = database.obs[key]['EXP_TYPE'][ww_sci[0]]
+                    hdul[0].header['EXPSTART'] = np.min(database.obs[key]['EXPSTART'][ww_sci])
+                    hdul[0].header['NINTS'] = np.sum(database.obs[key]['NINTS'][ww_sci])
+                    hdul[0].header['EFFINTTM'] = database.obs[key]['EFFINTTM'][ww_sci[0]]
+                    hdul[0].header['SUBARRAY'] = database.obs[key]['SUBARRAY'][ww_sci[0]]
+                    hdul[0].header['APERNAME'] = database.obs[key]['APERNAME'][ww_sci[0]]
+                    hdul[0].header['PIXSCALE'] = database.obs[key]['PIXSCALE'][ww_sci[0]]
                     hdul[0].header['MODE'] = mode
                     hdul[0].header['ANNULI'] = annu
                     hdul[0].header['SUBSECTS'] = subs
-                    hdul[0].header['BUNIT'] = Database.obs[key]['BUNIT'][ww_sci[0]]
+                    hdul[0].header['BUNIT'] = database.obs[key]['BUNIT'][ww_sci[0]]
                     hdul.writeto(datapath, output_verify='fix', overwrite=True)
                     hdul.close()
     
     # Read reductions into database.
-    Database.read_jwst_s3_data(datapaths)
+    database.read_jwst_s3_data(datapaths)
     
     pass

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -46,6 +46,7 @@ def read_obs(fitsfile):
     
     return data, erro, pxdq, head_pri, head_sci, is2d
 
+
 def write_obs(fitsfile,
               output_dir,
               data,
@@ -72,6 +73,7 @@ def write_obs(fitsfile,
     hdul.close()
     
     return fitsfile
+
 
 def read_red(fitsfile):
     

--- a/tests/test_miri_sky_1386.py
+++ b/tests/test_miri_sky_1386.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     # Additional step parameters can be passed using the steps parameter as
     # outlined here:
     # https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
-    coron1pipeline.run_obs(Database=Database,
+    coron1pipeline.run_obs(database=Database,
                            steps={'saturation': {'n_pix_grow_sat': 1,
                                                  'grow_diagonal': False},
                                   'refpix': {'odd_even_columns': True,
@@ -57,10 +57,10 @@ if __name__ == "__main__":
                                            'four_group_rejection_threshold': 8.},
                                   'ramp_fit': {'save_calibrated_ramp': False}},
                            subdir='stage1')
-    coron2pipeline.run_obs(Database=Database,
+    coron2pipeline.run_obs(database=Database,
                            steps={'outlier_detection': {'skip': False}},
                            subdir='stage2')
-    # coron3pipeline.run_obs(Database=Database,
+    # coron3pipeline.run_obs(database=database,
     #                        steps={'klip': {'truncate': 100}},
     #                        subdir='stage3')
     
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     
     # Run the pyKLIP pipeline. Additional parameters for the klip_dataset
     # function can be passed using the kwargs parameter.
-    pyklippipeline.run_obs(Database=Database,
+    pyklippipeline.run_obs(database=Database,
                            kwargs={'mode': ['ADI', 'RDI', 'ADI+RDI'],
                                    'annuli': [1, 5],
                                    'subsections': [1],

--- a/tests/test_nircam_sim_1441.py
+++ b/tests/test_nircam_sim_1441.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     # Additional step parameters can be passed using the steps parameter as
     # outlined here:
     # https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
-    coron1pipeline.run_obs(Database=Database,
+    coron1pipeline.run_obs(database=Database,
                            steps={'saturation': {'n_pix_grow_sat': 1,
                                                  'grow_diagonal': False},
                                   'refpix': {'odd_even_columns': True,
@@ -57,10 +57,10 @@ if __name__ == "__main__":
                                            'four_group_rejection_threshold': 4.},
                                   'ramp_fit': {'save_calibrated_ramp': False}},
                            subdir='stage1')
-    coron2pipeline.run_obs(Database=Database,
+    coron2pipeline.run_obs(database=Database,
                            steps={'outlier_detection': {'skip': False}},
                            subdir='stage2')
-    # coron3pipeline.run_obs(Database=Database,
+    # coron3pipeline.run_obs(database=database,
     #                        steps={'klip': {'truncate': 100}},
     #                        subdir='stage3')
     
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     
     # Run the pyKLIP pipeline. Additional parameters for the klip_dataset
     # function can be passed using the kwargs parameter.
-    pyklippipeline.run_obs(Database=Database,
+    pyklippipeline.run_obs(database=Database,
                            kwargs={'mode': ['ADI', 'RDI', 'ADI+RDI'],
                                    'annuli': [1, 5],
                                    'subsections': [1],

--- a/tests/test_nircam_sky_1386.py
+++ b/tests/test_nircam_sky_1386.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     # Additional step parameters can be passed using the steps parameter as
     # outlined here:
     # https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
-    coron1pipeline.run_obs(Database=Database,
+    coron1pipeline.run_obs(database=Database,
                            steps={'saturation': {'n_pix_grow_sat': 1,
                                                  'grow_diagonal': False},
                                   'refpix': {'odd_even_columns': True,
@@ -57,10 +57,10 @@ if __name__ == "__main__":
                                            'four_group_rejection_threshold': 4.},
                                   'ramp_fit': {'save_calibrated_ramp': False}},
                            subdir='stage1')
-    coron2pipeline.run_obs(Database=Database,
+    coron2pipeline.run_obs(database=Database,
                            steps={'outlier_detection': {'skip': False}},
                            subdir='stage2')
-    coron3pipeline.run_obs(Database=Database,
+    coron3pipeline.run_obs(database=Database,
                            steps={'klip': {'truncate': 100}},
                            subdir='stage3')
     
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     
     # Run the pyKLIP pipeline. Additional parameters for the klip_dataset
     # function can be passed using the kwargs parameter.
-    pyklippipeline.run_obs(Database=Database,
+    pyklippipeline.run_obs(database=Database,
                            kwargs={'mode': ['ADI', 'RDI', 'ADI+RDI'],
                                    'annuli': [1, 5],
                                    'subsections': [1],

--- a/tests/test_nircam_sky_1441.py
+++ b/tests/test_nircam_sky_1441.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     # Additional step parameters can be passed using the steps parameter as
     # outlined here:
     # https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
-    coron1pipeline.run_obs(Database=Database,
+    coron1pipeline.run_obs(database=Database,
                            steps={'saturation': {'n_pix_grow_sat': 1,
                                                  'grow_diagonal': False},
                                   'refpix': {'odd_even_columns': True,
@@ -57,10 +57,10 @@ if __name__ == "__main__":
                                            'four_group_rejection_threshold': 4.},
                                   'ramp_fit': {'save_calibrated_ramp': False}},
                            subdir='stage1')
-    coron2pipeline.run_obs(Database=Database,
+    coron2pipeline.run_obs(database=Database,
                            steps={'outlier_detection': {'skip': False}},
                            subdir='stage2')
-    # coron3pipeline.run_obs(Database=Database,
+    # coron3pipeline.run_obs(database=database,
     #                        steps={'klip': {'truncate': 100}},
     #                        subdir='stage3')
     
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     
     # Run the pyKLIP pipeline. Additional parameters for the klip_dataset
     # function can be passed using the kwargs parameter.
-    pyklippipeline.run_obs(Database=Database,
+    pyklippipeline.run_obs(database=Database,
                            kwargs={'mode': ['ADI', 'RDI', 'ADI+RDI'],
                                    'annuli': [1, 5],
                                    'subsections': [1],

--- a/tests/test_niriss_sky_1093.py
+++ b/tests/test_niriss_sky_1093.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     # Additional step parameters can be passed using the steps parameter as
     # outlined here:
     # https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
-    coron1pipeline.run_obs(Database=Database,
+    coron1pipeline.run_obs(database=Database,
                            steps={'saturation': {'n_pix_grow_sat': 1,
                                                  'grow_diagonal': False},
                                   'ipc': {'skip': True},
@@ -58,12 +58,12 @@ if __name__ == "__main__":
                                            'four_group_rejection_threshold': 4.},
                                   'ramp_fit': {'save_calibrated_ramp': False}},
                            subdir='stage1')
-    coron2pipeline.run_obs(Database=Database,
+    coron2pipeline.run_obs(database=Database,
                            steps={'photom': {'skip': True},
                                   'resample': {'skip': True},
                                   'outlier_detection': {'skip': True}},
                            subdir='stage2')
-    # coron3pipeline.run_obs(Database=Database,
+    # coron3pipeline.run_obs(database=database,
     #                        steps={'klip': {'truncate': 100}},
     #                        subdir='stage3')
     
@@ -133,7 +133,7 @@ if __name__ == "__main__":
     
     # Run the pyKLIP pipeline. Additional parameters for the klip_dataset
     # function can be passed using the kwargs parameter.
-    pyklippipeline.run_obs(Database=Database,
+    pyklippipeline.run_obs(database=Database,
                            kwargs={'mode': ['RDI'],
                                    'annuli': [1],
                                    'subsections': [1],


### PR DESCRIPTION
This PR (mostly autogenerated with PyCharm) improves PEP8 style compliance for the refactored spaceklip. 
Mostly this involves renaming variables to follow the convention that all variable names should be lowercase, and initial capitals are restricted to class names. (In particular `Database` for the class and `database` and `self.database` for variable instances of that class). 

This also includes some PEP8 compliance fixes to whitespace and a few other misc things. To keep scope manageable and this PR somewhat more reviewable, this doesn't attempt to address all PEP8 compliance issues comprehensively. 