### PR TITLE
add missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@ jdaviz
 jwst
 matplotlib
 numpy
+pyklip
 scipy
 webbpsf
+webbpsf_ext


### PR DESCRIPTION
Very minor PR: pyklip and webbpsf_ext are both used, but were missing from the requirements.txt. Clearly pyklip is required :-) 